### PR TITLE
get time from NTP serve once, then set to RTC DS3231

### DIFF
--- a/saladin-eye-ai-device-esp32-s3/platformio.ini
+++ b/saladin-eye-ai-device-esp32-s3/platformio.ini
@@ -27,3 +27,6 @@ build_flags = -DCORE_DEBUG_LEVEL=5
 
 lib_deps = 
   arduino-libraries/NTPClient@^3.2.1
+  adafruit/Adafruit BusIO@^1.16.1
+  adafruit/RTClib@^2.1.4
+  SPI


### PR DESCRIPTION
**Overview:**
This PR introduces code changes to fetch the accurate time from an NTP server at startup and synchronize it with the RTC DS3231 module. Subsequently, it retrieves the latest date and time from the RTC DS3231 module. To address the https://github.com/andypmw/saladin-eye-ai/issues/5 issue.

**Changes:**
- **NTP Time Synchronization:**
  - Implemented code to connect to an NTP server and obtain the current date and time.
  - The time is fetched once during startup to ensure the RTC DS3231 module is initialized with accurate time data.

- **RTC DS3231 Module Integration:**
  - Added functionality to set the RTC DS3231 module with the time retrieved from the NTP server.
  - Included code to read the latest date and time from the RTC DS3231 module after initialization.

**Details:**
1. **Startup Synchronization:**
   - On startup, the system connects to the specified NTP server and fetches the current time.
   - The obtained time is then used to set the RTC DS3231 module, ensuring it starts with the correct date and time.

2. **RTC Read Functionality:**
   - Implemented a function to retrieve the latest date and time from the RTC DS3231 module.
   - This ensures that the system can always access the most recent time data from the RTC module.

**Testing:**
- Verified that the NTP synchronization occurs correctly during startup.
- Confirmed that the RTC DS3231 module is accurately set with the NTP time.
- Ensured that reading from the RTC DS3231 module returns the correct date and time.

**Dependencies:**
- Requires the NTP client library for time synchronization.
- Utilizes the DS3231 RTC library for interfacing with the RTC module.

**Notes:**
- Ensure the NTP server details are correctly configured in the code for successful time synchronization.
- The RTC DS3231 module should be properly connected and functional to reflect accurate time data.
