### PR TITLE
Add MQTT Connectivity, Online Status Reporting, and Command Subscription

### DIFF
--- a/saladin-eye-ai-device-esp32-s3/platformio.ini
+++ b/saladin-eye-ai-device-esp32-s3/platformio.ini
@@ -29,4 +29,5 @@ lib_deps =
   arduino-libraries/NTPClient@^3.2.1
   adafruit/Adafruit BusIO@^1.16.1
   adafruit/RTClib@^2.1.4
+  knolleary/PubSubClient@^2.8
   SPI


### PR DESCRIPTION
This pull request introduces the following features to the SaladinEye ESP32 CCTV firmware:

1. **MQTT Broker Connection & Maintenance**:
    - Implemented code to connect the ESP32 device to the specified MQTT broker using the configured connection parameters (broker address, port, credentials).
    - Added logic to maintain the connection, including automatic reconnection if the connection is lost.

2. **Publish Online Status**:
    - Implemented a feature to publish a message to a `status` topic every 30 seconds, indicating the device's online status.
    - The status message includes the device ID

3. **Subscribe to Command Topic**:
    - Added code to subscribe to a `command` topic, allowing the device to receive and process commands from the backend server via MQTT broker.
    - Implemented a basic command handler to parse and execute received commands (for demo purpose, to turning LED on and off).

#### Testing
- Verified that the ESP32 device successfully connects to the MQTT broker.
- Tested the online status message to ensure it is published every 30 seconds.
- Subscribed to the `command` topic and confirmed that commands sent from the backend are received and processed correctly. (the onboard LED is turning on and off)
- Simulated connection drops and confirmed that the reconnection logic works as expected.

#### Notes
- For long term usage, ensure the MQTT broker credentials are securely stored and need to employ a proper method to generate short-term credential.
- Consider potential improvements, such as encrypting messages and implementing more sophisticated command handling.

#### Related Issues
- GitHub issue https://github.com/andypmw/saladin-eye-ai/issues/15
