### PR TITLE
camera-service: implement gRPC server logic and add proto

### DIFF
--- a/saladin-eye-ai-microservices/camera-service/Makefile
+++ b/saladin-eye-ai-microservices/camera-service/Makefile
@@ -1,0 +1,7 @@
+# Define the proto source directory and output directory
+PROTO_SRC_DIR := ../../saladin-eye-ai-protos
+PROTO_OUT_DIR := .
+
+# To generate Go and gRPC code from proto files
+genproto:
+	protoc --proto_path=$(PROTO_SRC_DIR) --go_out=$(PROTO_OUT_DIR) --go-grpc_out=$(PROTO_OUT_DIR) $(PROTO_SRC_DIR)/*.proto

--- a/saladin-eye-ai-microservices/camera-service/cmd/camera-service/main.go
+++ b/saladin-eye-ai-microservices/camera-service/cmd/camera-service/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/andypmw/saladin-eye-ai/camera-service/common/genproto"
+	"github.com/go-redis/redis/v8"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	ctx = context.Background()
+	rdb *redis.Client
+)
+
+func init() {
+	// Initialize Redis client
+	redisAddr := os.Getenv("REDIS_ADDR")
+	if redisAddr == "" {
+		log.Fatal().Msg("redis address is not set in the environment variables")
+	}
+
+	rdb = redis.NewClient(&redis.Options{
+		Addr: redisAddr,
+	})
+}
+
+type CameraService struct {
+	genproto.UnimplementedCameraServiceServer
+}
+
+func (CameraService) GetCameraStatus(_ context.Context, req *genproto.GetCameraStatusRequest) (*genproto.GetCameraStatusResponse, error) {
+	deviceId := req.DeviceId
+
+	log.Debug().Msgf("GetCameraStatus for device_id %s", deviceId)
+
+	// Get the camera online presence status from Redis
+	key := fmt.Sprintf("saladin-eye:camera-service:device-online-presence:%s", deviceId)
+	cameraStatus, err := rdb.Get(ctx, key).Result()
+	if err != nil {
+		if err != redis.Nil {
+			return nil, status.Errorf(codes.Internal, "internal error: %v", err)
+		}
+	}
+
+	response := genproto.GetCameraStatusResponse{
+		DeviceId: deviceId,
+		IsOnline: cameraStatus == "1",
+	}
+
+	return &response, nil
+}
+
+func main() {
+	// Log setup
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+
+	// Start gRPC server
+	server := grpc.NewServer()
+	var cameraService CameraService
+	genproto.RegisterCameraServiceServer(server, cameraService)
+
+	log.Info().Msg("SaladinEye.AI - gRPC Server - Camera Service")
+
+	port := os.Getenv("GRPC_PORT")
+	if port == "" {
+		log.Fatal().Msg("GRPC_PORT environment variable not set")
+	}
+
+	l, err := net.Listen("tcp", port)
+	if err != nil {
+		log.Fatal().Msgf("could not listen to %s: %v", port, err)
+	}
+
+	log.Fatal().Err(server.Serve(l))
+}

--- a/saladin-eye-ai-protos/camera-service.proto
+++ b/saladin-eye-ai-protos/camera-service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package saladineye;
+
+option go_package = "./common/genproto";
+
+service CameraService {
+  rpc GetCameraStatus(GetCameraStatusRequest) returns (GetCameraStatusResponse) {}
+}
+
+message GetCameraStatusRequest {
+  string device_id = 1;
+}
+
+message GetCameraStatusResponse {
+  string device_id = 1;
+  bool is_online = 2;
+}


### PR DESCRIPTION
Implement gRPC server logic and add proto for camera-service

This PR adds core functionality to the camera-service:

- Defined service interface in .proto file
- Implemented gRPC server logic

Key changes:
- Implemented CameraServiceServer interface
- Added gRPC server setup in main.go

This PR to address the issue https://github.com/andypmw/saladin-eye-ai/issues/17