### PR TITLE
Implement media-service gRPC microservice for Cloudflare R2 presigned URL generation

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -7,11 +7,13 @@ github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZ
 github.com/golang/glog v1.2.1/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.25.0 h1:ypSNr+bnYL2YhwoMt2zPxHFmbAN1KZs/njMG3hxUp30=
 golang.org/x/crypto v0.25.0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/oauth2 v0.20.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2/go.mod h1:TeRTkGYfJXctD9OcfyVLyj2J3IxLnKwHJR8f4D8a3YE=
 golang.org/x/term v0.22.0/go.mod h1:F3qCibpT5AMpCRfhfT53vVJwhLtIVHhB9XDjfFvnMI4=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/saladin-eye-ai-microservices/media-service/Makefile
+++ b/saladin-eye-ai-microservices/media-service/Makefile
@@ -1,0 +1,7 @@
+# Define the proto source directory and output directory
+PROTO_SRC_DIR := ../../saladin-eye-ai-protos
+PROTO_OUT_DIR := .
+
+# To generate Go and gRPC code from proto files
+genproto:
+	protoc --proto_path=$(PROTO_SRC_DIR) --go_out=$(PROTO_OUT_DIR) --go-grpc_out=$(PROTO_OUT_DIR) $(PROTO_SRC_DIR)/media-service.proto

--- a/saladin-eye-ai-microservices/media-service/cmd/media-service/main.go
+++ b/saladin-eye-ai-microservices/media-service/cmd/media-service/main.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/andypmw/saladin-eye-ai/media-service/common/genproto"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	s3Client   *s3.S3
+	bucketName string
+)
+
+func init() {
+	// Get R2 credentials from environment variables
+	accountID := os.Getenv("R2_ACCOUNT_ID")
+	accessKeyID := os.Getenv("R2_ACCESS_KEY_ID")
+	secretAccessKey := os.Getenv("R2_SECRET_ACCESS_KEY")
+	bucketName = os.Getenv("R2_BUCKET")
+
+	// Check if all required environment variables are set
+	if accountID == "" || accessKeyID == "" || secretAccessKey == "" || bucketName == "" {
+		log.Fatal().Msg("missing Cloudflare R2 credentials in environment variables")
+	}
+
+	// Create a new AWS session
+	awsSession, err := session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(accessKeyID, secretAccessKey, ""),
+		Endpoint:    aws.String(fmt.Sprintf("https://%s.r2.cloudflarestorage.com", accountID)),
+		Region:      aws.String("auto"),
+	})
+	if err != nil {
+		log.Fatal().Msgf("failed to create cloudflare R2 session: %v", err)
+	}
+
+	// Create S3 service client
+	s3Client = s3.New(awsSession)
+
+	// Dummy call to list objects in the bucket with a limit of 1
+	input := &s3.ListObjectsV2Input{
+		Bucket:  aws.String(bucketName),
+		MaxKeys: aws.Int64(1),
+	}
+
+	_, err = s3Client.ListObjectsV2(input)
+	if err != nil {
+		log.Fatal().Msgf("unable to list objects in bucket %s: %v", bucketName, err)
+	}
+}
+
+type MediaService struct {
+	genproto.UnimplementedMediaServiceServer
+}
+
+/**
+ * The media files in the object storage will be grouped like this:
+ *   [Device ID]/[YYYY-MM-DD]/[HH]/[mm]-[ss].jpg
+ *
+ * The date time will be in UTC.
+ */
+func (MediaService) GetPhotoUploadUrl(_ context.Context, req *genproto.GetPhotoUploadUrlRequest) (*genproto.GetPhotoUploadUrlResponse, error) {
+	deviceId := strings.TrimSpace(req.DeviceId)
+
+	if len(deviceId) != 9 {
+		log.Error().Msgf("invalid device_id %s length %d", deviceId, len(deviceId))
+		return nil, status.Errorf(codes.InvalidArgument, "invalid device_id length: %d", len(deviceId))
+	}
+
+	log.Debug().Msgf("GetPhotoUploadUrl for device_id %s", deviceId)
+
+	// Generate the file name based on the current UTC time
+	now := time.Now().UTC()
+	fileName := fmt.Sprintf("%s/%s/%02d/%02d-%02d.jpg", deviceId, now.Format("2006-01-02"), now.Hour(), now.Minute(), now.Second())
+
+	// Generate presigned URL
+	s3req, _ := s3Client.PutObjectRequest(&s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(fileName),
+	})
+	uploadUrlStr, err := s3req.Presign(15 * time.Minute)
+	if err != nil {
+		log.Error().Msgf("failed to generate presigned URL: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to generate presigned URL: %v", err)
+	}
+
+	return &genproto.GetPhotoUploadUrlResponse{
+		DeviceId:  deviceId,
+		UploadUrl: uploadUrlStr,
+	}, nil
+}
+
+func main() {
+	// Log setup
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+
+	// Start gRPC server
+	server := grpc.NewServer()
+	var mediaService MediaService
+	genproto.RegisterMediaServiceServer(server, mediaService)
+
+	log.Info().Msg("SaladinEye.AI - gRPC Server - Media Service")
+
+	port := os.Getenv("GRPC_PORT")
+	if port == "" {
+		log.Fatal().Msg("GRPC_PORT environment variable not set")
+	}
+
+	l, err := net.Listen("tcp", port)
+	if err != nil {
+		log.Fatal().Msgf("could not listen to %s: %v", port, err)
+	}
+
+	log.Fatal().Err(server.Serve(l))
+}

--- a/saladin-eye-ai-microservices/media-service/go.mod
+++ b/saladin-eye-ai-microservices/media-service/go.mod
@@ -1,0 +1,21 @@
+module github.com/andypmw/saladin-eye-ai/media-service
+
+go 1.22
+
+require (
+	github.com/aws/aws-sdk-go v1.55.5
+	github.com/rs/zerolog v1.33.0
+	google.golang.org/grpc v1.65.0
+	google.golang.org/protobuf v1.34.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	golang.org/x/net v0.25.0 // indirect
+	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/text v0.15.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157 // indirect
+)

--- a/saladin-eye-ai-protos/media-service.proto
+++ b/saladin-eye-ai-protos/media-service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package saladineye;
+
+option go_package = "./common/genproto";
+
+service MediaService {
+  rpc GetPhotoUploadUrl(GetPhotoUploadUrlRequest) returns (GetPhotoUploadUrlResponse) {}
+}
+
+message GetPhotoUploadUrlRequest {
+  string device_id = 1;
+}
+
+message GetPhotoUploadUrlResponse {
+  string device_id = 1;
+  string upload_url = 2;
+}


### PR DESCRIPTION
This PR implements the `media-service` gRPC microservice, which allows ESP32 CCTV microcontrollers to obtain presigned HTTP upload URLs for Cloudflare R2 object storage. The implementation includes the core service logic, protobuf definition, and build tools.

Key changes:

1. gRPC Service Implementation:
   - Implemented `GetPhotoUploadUrl` method to generate presigned URLs for Cloudflare R2

2. Protobuf Definition:
   - Created `media-service.proto` with service and message definitions
   - Defined `GetPhotoUploadUrl` RPC method
   - Added message types for request and response objects

3. Build and Development Tools:
   - Added `Makefile` to execute protoc

4. Dependencies:
   - Updated `go.mod` with required dependencies

This PR related to the issue https://github.com/andypmw/saladin-eye-ai/issues/21