### PR TITLE
chore(ctx): Pass gRPC Call Context Down to Service and Internal Layers

### DIFF
--- a/saladin-eye-ai-microservices/media-service/handler/grpc/grpc.go
+++ b/saladin-eye-ai-microservices/media-service/handler/grpc/grpc.go
@@ -27,10 +27,10 @@ func New() *MediaService {
 	}
 }
 
-func (handler MediaService) GetPhotoUploadUrl(_ context.Context, req *genproto.GetPhotoUploadUrlRequest) (*genproto.GetPhotoUploadUrlResponse, error) {
+func (handler MediaService) GetPhotoUploadUrl(ctx context.Context, req *genproto.GetPhotoUploadUrlRequest) (*genproto.GetPhotoUploadUrlResponse, error) {
 	deviceId := strings.TrimSpace(req.DeviceId)
 
-	uploadURL, err := handler.photoService.GenerateUploadPresignedUrl(deviceId)
+	uploadURL, err := handler.photoService.GenerateUploadPresignedUrl(ctx, deviceId)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to generate presigned photo upload URL: %v", err)
 	}
@@ -46,7 +46,7 @@ func (handler MediaService) ListFilesByDateHour(ctx context.Context, req *genpro
 	date := strings.TrimSpace(req.Date)
 	hour := req.Hour
 
-	result, err := handler.photoService.ListObjectsByDateHour(deviceId, date, hour)
+	result, err := handler.photoService.ListObjectsByDateHour(ctx, deviceId, date, hour)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list files by date hour: %v", err)
 	}

--- a/saladin-eye-ai-microservices/media-service/internal/objectstorage/cloudflare-r2.go
+++ b/saladin-eye-ai-microservices/media-service/internal/objectstorage/cloudflare-r2.go
@@ -1,6 +1,7 @@
 package objectstorage
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -47,7 +48,7 @@ func (objs *CloudflareR2) Init() error {
 	return nil
 }
 
-func (objs *CloudflareR2) GeneratePresignedUploadUrl(path string, durationMinute int) (string, error) {
+func (objs *CloudflareR2) GeneratePresignedUploadUrl(ctx context.Context, path string, durationMinute int) (string, error) {
 	s3req, _ := objs.s3Client.PutObjectRequest(&s3.PutObjectInput{
 		Bucket: aws.String(objs.bucketName),
 		Key:    aws.String(path),
@@ -60,7 +61,7 @@ func (objs *CloudflareR2) GeneratePresignedUploadUrl(path string, durationMinute
 	return uploadUrlStr, nil
 }
 
-func (objs *CloudflareR2) GeneratePresignedDownloadUrl(path string, durationMinute int) (string, error) {
+func (objs *CloudflareR2) GeneratePresignedDownloadUrl(ctx context.Context, path string, durationMinute int) (string, error) {
 	s3req, _ := objs.s3Client.GetObjectRequest(&s3.GetObjectInput{
 		Bucket: aws.String(objs.bucketName),
 		Key:    aws.String(path),
@@ -73,7 +74,7 @@ func (objs *CloudflareR2) GeneratePresignedDownloadUrl(path string, durationMinu
 	return downloadUrlStr, nil
 }
 
-func (objs *CloudflareR2) ListObjectsByPrefix(prefix string) ([]string, error) {
+func (objs *CloudflareR2) ListObjectsByPrefix(ctx context.Context, prefix string) ([]string, error) {
 	filenames := make([]string, 0)
 
 	resp, err := objs.s3Client.ListObjectsV2(&s3.ListObjectsV2Input{

--- a/saladin-eye-ai-microservices/media-service/internal/objectstorage/types.go
+++ b/saladin-eye-ai-microservices/media-service/internal/objectstorage/types.go
@@ -1,8 +1,10 @@
 package objectstorage
 
+import "context"
+
 type ObjectStorageIface interface {
 	Init() error
-	GeneratePresignedUploadUrl(path string, durationMinute int) (string, error)
-	GeneratePresignedDownloadUrl(path string, durationMinute int) (string, error)
-	ListObjectsByPrefix(prefix string) ([]string, error)
+	GeneratePresignedUploadUrl(ctx context.Context, path string, durationMinute int) (string, error)
+	GeneratePresignedDownloadUrl(ctx context.Context, path string, durationMinute int) (string, error)
+	ListObjectsByPrefix(ctx context.Context, prefix string) ([]string, error)
 }


### PR DESCRIPTION
This pull request introduces changes to pass the context from the gRPC call through to the service and internal layers. This enhancement ensures consistent context propagation, allowing for better handling of deadlines, cancellations, and tracing information across the entire request lifecycle.

#### Changes:
- **gRPC Handler:** Updated to extract the context from incoming gRPC requests.
- **Service Layer:** Modified to accept and propagate the context received from the gRPC handler.
- **Internal Methods:** Refactored to include context as a parameter, ensuring context is passed down to all lower-level functions and components.
  
#### Benefits:
- **Context Awareness:** By passing context down the stack, we improve our ability to manage request deadlines, cancellations, and tracing, leading to more robust and responsive services.
- **Traceability:** Enhanced traceability across the service layers, aiding in debugging and monitoring.
- **Consistency:** Establishes a consistent pattern for context usage across the codebase.