### PR TITLE
feat(media-service): implement ListDate and ListHourByDate

### DIFF
--- a/saladin-eye-ai-microservices/media-service/internal/objectstorage/types.go
+++ b/saladin-eye-ai-microservices/media-service/internal/objectstorage/types.go
@@ -7,4 +7,6 @@ type ObjectStorageIface interface {
 	GeneratePresignedUploadUrl(ctx context.Context, path string, durationMinute int) (string, error)
 	GeneratePresignedDownloadUrl(ctx context.Context, path string, durationMinute int) (string, error)
 	ListObjectsByPrefix(ctx context.Context, prefix string) ([]string, error)
+	ListDate(ctx context.Context, deviceId string) ([]string, error)
+	ListHourByDate(ctx context.Context, deviceId, date string) ([]string, error)
 }

--- a/saladin-eye-ai-microservices/media-service/service/photo/types.go
+++ b/saladin-eye-ai-microservices/media-service/service/photo/types.go
@@ -1,6 +1,15 @@
 package photo
 
+import "context"
+
 type ObjectFile struct {
 	Name        string
 	DownloadUrl string
+}
+
+type PhotoServiceIface interface {
+	GenerateUploadPresignedUrl(ctx context.Context, deviceId, idempotentKey string) (string, error)
+	ListDate(ctx context.Context, deviceId string) ([]string, error)
+	ListHourByDate(ctx context.Context, deviceId, date string) ([]string, error)
+	ListObjectsByDateHour(ctx context.Context, deviceId string, date string, hour int32) ([]ObjectFile, error)
 }


### PR DESCRIPTION
This PR implements two new endpoints in the `media-service` microservice for MQTT handler:
1. **`ListDate`**: Retrieves a list of dates when a specific camera has uploaded pictures to the backend storage.
2. **`ListHourByDate`**: Retrieves a list of hours within a given date when a specific camera has uploaded pictures to the backend storage.

- **Core Logic**:
  - Queries the backend storage (e.g., AWS S3, Cloudflare R2) for upload metadata, extracting relevant dates and hours.
  - Optimized handling of large datasets and metadata processing.
  
- **Error Handling**:
  - Returns `404 Not Found` if no uploads are found for the camera or date.
  - Proper validation for inputs, ensuring valid camera IDs and date formats.

Related to issue https://github.com/andypmw/saladin-eye-ai/issues/41
